### PR TITLE
Fix tailwind css errors in global.css

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,6 +1,4 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+@import "tailwindcss";
 
 @custom-variant dark (&:is(.dark *));
 


### PR DESCRIPTION
Replace `@tailwind` directives with `@import "tailwindcss";` in `src/styles/globals.css` to align with Tailwind v4 syntax.

---
<a href="https://cursor.com/background-agent?bcId=bc-9d2d6004-53d1-49dc-98b6-a088172cab09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9d2d6004-53d1-49dc-98b6-a088172cab09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

